### PR TITLE
feat: Add daisyUI theme switcher to settings page

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -15,7 +15,7 @@
    curl -sLO https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.js
    Make sure to look at the daisyUI changelog: https://daisyui.com/docs/changelog/ */
 @plugin "../vendor/daisyui" {
-  themes: false;
+    themes: false;
 }
 
 /* daisyUI theme plugin. You can update this file by fetching the latest version with:
@@ -23,73 +23,181 @@
   We ship with two themes, a light one inspired on Phoenix colors and a dark one inspired
   on Elixir colors. Build your own at: https://daisyui.com/theme-generator/ */
 @plugin "../vendor/daisyui-theme" {
-  name: "dark";
-  default: false;
-  prefersdark: true;
-  color-scheme: "dark";
-  --color-base-100: oklch(30.33% 0.016 252.42);
-  --color-base-200: oklch(25.26% 0.014 253.1);
-  --color-base-300: oklch(20.15% 0.012 254.09);
-  --color-base-content: oklch(97.807% 0.029 256.847);
-  --color-primary: oklch(58% 0.233 277.117);
-  --color-primary-content: oklch(96% 0.018 272.314);
-  --color-secondary: oklch(58% 0.233 277.117);
-  --color-secondary-content: oklch(96% 0.018 272.314);
-  --color-accent: oklch(60% 0.25 292.717);
-  --color-accent-content: oklch(96% 0.016 293.756);
-  --color-neutral: oklch(37% 0.044 257.287);
-  --color-neutral-content: oklch(98% 0.003 247.858);
-  --color-info: oklch(58% 0.158 241.966);
-  --color-info-content: oklch(97% 0.013 236.62);
-  --color-success: oklch(60% 0.118 184.704);
-  --color-success-content: oklch(98% 0.014 180.72);
-  --color-warning: oklch(66% 0.179 58.318);
-  --color-warning-content: oklch(98% 0.022 95.277);
-  --color-error: oklch(58% 0.253 17.585);
-  --color-error-content: oklch(96% 0.015 12.422);
-  --radius-selector: 0.25rem;
-  --radius-field: 0.25rem;
-  --radius-box: 0.5rem;
-  --size-selector: 0.21875rem;
-  --size-field: 0.21875rem;
-  --border: 1.5px;
-  --depth: 1;
-  --noise: 0;
+    name: "dark";
+    default: false;
+    prefersdark: true;
+    color-scheme: "dark";
+    --color-base-100: oklch(30.33% 0.016 252.42);
+    --color-base-200: oklch(25.26% 0.014 253.1);
+    --color-base-300: oklch(20.15% 0.012 254.09);
+    --color-base-content: oklch(97.807% 0.029 256.847);
+    --color-primary: oklch(58% 0.233 277.117);
+    --color-primary-content: oklch(96% 0.018 272.314);
+    --color-secondary: oklch(58% 0.233 277.117);
+    --color-secondary-content: oklch(96% 0.018 272.314);
+    --color-accent: oklch(60% 0.25 292.717);
+    --color-accent-content: oklch(96% 0.016 293.756);
+    --color-neutral: oklch(37% 0.044 257.287);
+    --color-neutral-content: oklch(98% 0.003 247.858);
+    --color-info: oklch(58% 0.158 241.966);
+    --color-info-content: oklch(97% 0.013 236.62);
+    --color-success: oklch(60% 0.118 184.704);
+    --color-success-content: oklch(98% 0.014 180.72);
+    --color-warning: oklch(66% 0.179 58.318);
+    --color-warning-content: oklch(98% 0.022 95.277);
+    --color-error: oklch(58% 0.253 17.585);
+    --color-error-content: oklch(96% 0.015 12.422);
+    --radius-selector: 0.25rem;
+    --radius-field: 0.25rem;
+    --radius-box: 0.5rem;
+    --size-selector: 0.21875rem;
+    --size-field: 0.21875rem;
+    --border: 1.5px;
+    --depth: 1;
+    --noise: 0;
 }
 
 @plugin "../vendor/daisyui-theme" {
-  name: "light";
-  default: true;
-  prefersdark: false;
-  color-scheme: "light";
-  --color-base-100: oklch(98% 0 0);
-  --color-base-200: oklch(96% 0.001 286.375);
-  --color-base-300: oklch(92% 0.004 286.32);
-  --color-base-content: oklch(21% 0.006 285.885);
-  --color-primary: oklch(70% 0.213 47.604);
-  --color-primary-content: oklch(98% 0.016 73.684);
-  --color-secondary: oklch(55% 0.027 264.364);
-  --color-secondary-content: oklch(98% 0.002 247.839);
-  --color-accent: oklch(0% 0 0);
-  --color-accent-content: oklch(100% 0 0);
-  --color-neutral: oklch(44% 0.017 285.786);
-  --color-neutral-content: oklch(98% 0 0);
-  --color-info: oklch(62% 0.214 259.815);
-  --color-info-content: oklch(97% 0.014 254.604);
-  --color-success: oklch(70% 0.14 182.503);
-  --color-success-content: oklch(98% 0.014 180.72);
-  --color-warning: oklch(66% 0.179 58.318);
-  --color-warning-content: oklch(98% 0.022 95.277);
-  --color-error: oklch(58% 0.253 17.585);
-  --color-error-content: oklch(96% 0.015 12.422);
-  --radius-selector: 0.25rem;
-  --radius-field: 0.25rem;
-  --radius-box: 0.5rem;
-  --size-selector: 0.21875rem;
-  --size-field: 0.21875rem;
-  --border: 1.5px;
-  --depth: 1;
-  --noise: 0;
+    name: "light";
+    default: true;
+    prefersdark: false;
+    color-scheme: "light";
+    --color-base-100: oklch(98% 0 0);
+    --color-base-200: oklch(96% 0.001 286.375);
+    --color-base-300: oklch(92% 0.004 286.32);
+    --color-base-content: oklch(21% 0.006 285.885);
+    --color-primary: oklch(70% 0.213 47.604);
+    --color-primary-content: oklch(98% 0.016 73.684);
+    --color-secondary: oklch(55% 0.027 264.364);
+    --color-secondary-content: oklch(98% 0.002 247.839);
+    --color-accent: oklch(0% 0 0);
+    --color-accent-content: oklch(100% 0 0);
+    --color-neutral: oklch(44% 0.017 285.786);
+    --color-neutral-content: oklch(98% 0 0);
+    --color-info: oklch(62% 0.214 259.815);
+    --color-info-content: oklch(97% 0.014 254.604);
+    --color-success: oklch(70% 0.14 182.503);
+    --color-success-content: oklch(98% 0.014 180.72);
+    --color-warning: oklch(66% 0.179 58.318);
+    --color-warning-content: oklch(98% 0.022 95.277);
+    --color-error: oklch(58% 0.253 17.585);
+    --color-error-content: oklch(96% 0.015 12.422);
+    --radius-selector: 0.25rem;
+    --radius-field: 0.25rem;
+    --radius-box: 0.5rem;
+    --size-selector: 0.21875rem;
+    --size-field: 0.21875rem;
+    --border: 1.5px;
+    --depth: 1;
+    --noise: 0;
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "cupcake";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "bumblebee";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "emerald";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "corporate";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "synthwave";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "retro";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "cyberpunk";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "valentine";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "halloween";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "garden";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "forest";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "aqua";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "lofi";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "pastel";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "fantasy";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "wireframe";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "black";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "luxury";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "dracula";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "cmyk";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "autumn";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "business";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "acid";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "lemonade";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "night";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "coffee";
+}
+
+@plugin "../vendor/daisyui-theme" {
+    name: "winter";
 }
 
 /* Add variants based on LiveView classes */
@@ -98,6 +206,8 @@
 @custom-variant phx-change-loading (.phx-change-loading&, .phx-change-loading &);
 
 /* Make LiveView wrapper divs transparent for layout */
-[data-phx-session] { display: contents }
+[data-phx-session] {
+    display: contents;
+}
 
 /* This file is for your main application CSS */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,6 +24,7 @@ import { Socket } from "phoenix";
 import { LiveSocket } from "phoenix_live_view";
 import topbar from "../vendor/topbar";
 import Modal from "./modal";
+import ThemeSwitcher, { initTheme } from "./theme_switcher";
 
 const csrfToken = document
   .querySelector("meta[name='csrf-token']")
@@ -31,7 +32,7 @@ const csrfToken = document
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: { _csrf_token: csrfToken },
-  hooks: { Modal },
+  hooks: { Modal, ThemeSwitcher },
   dom: {
     // enuse that the <dialog> and <details> elements stay open when liveview updates
     onBeforeElUpdated: (fromEl, toEl) => {
@@ -51,6 +52,7 @@ window.addEventListener("phx:page-loading-stop", (_info) => topbar.hide());
 
 // connect if there are any LiveViews on the page
 liveSocket.connect();
+initTheme();
 
 // expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()

--- a/assets/js/theme_switcher.js
+++ b/assets/js/theme_switcher.js
@@ -1,0 +1,62 @@
+export default ThemeSwitcher = {
+  getActiveButton(theme) {
+    return this.el.querySelector(`[data-set-theme='${theme}']`);
+  },
+
+  highlightButton(button) {
+    if (button) {
+      this.unhighlightButton();
+      button.classList.add("btn-active", "border-primary");
+    }
+  },
+
+  unhighlightButton() {
+    this.el.querySelectorAll(".btn-active").forEach((button) => {
+      button.classList.remove("btn-active", "border-primary");
+    });
+  },
+
+  mounted() {
+    loadTheme((theme) => {
+      this.highlightButton(this.getActiveButton(theme));
+    });
+
+    this.el.addEventListener("change", (event) => {
+      this.newThemeSelected(event, (selectedTheme) => {
+        setTheme(selectedTheme);
+        this.highlightButton(this.getActiveButton(selectedTheme));
+      });
+    });
+  },
+
+  newThemeSelected({ target: target }, callback) {
+    if (target.name === "theme-dropdown") {
+      const selectedTheme = target.getAttribute("data-set-theme");
+      if (selectedTheme) {
+        callback(selectedTheme);
+      }
+    }
+  },
+
+  updated() {
+    loadTheme((theme) => {
+      this.highlightButton(this.getActiveButton(theme));
+    });
+  },
+};
+
+function loadTheme(onLoaded) {
+  const savedTheme = localStorage.getItem("theme");
+  if (savedTheme) {
+    onLoaded(savedTheme || "light");
+  }
+}
+
+function setTheme(theme) {
+  document.documentElement.setAttribute("data-theme", theme);
+  localStorage.setItem("theme", theme);
+}
+
+export function initTheme() {
+  loadTheme(setTheme);
+}

--- a/assets/js/theme_switcher.js
+++ b/assets/js/theme_switcher.js
@@ -47,9 +47,8 @@ export default ThemeSwitcher = {
 
 function loadTheme(onLoaded) {
   const savedTheme = localStorage.getItem("theme");
-  if (savedTheme) {
-    onLoaded(savedTheme || "light");
-  }
+  const themeToLoad = savedTheme || "light";
+  onLoaded(themeToLoad);
 }
 
 function setTheme(theme) {

--- a/lib/wedid_web/components/app_components.ex
+++ b/lib/wedid_web/components/app_components.ex
@@ -173,7 +173,7 @@ defmodule WedidWeb.AppComponents do
 
   def couple_card(assigns) do
     ~H"""
-    <div class="card bg-base-100 shadow-xl border-t-4 border-primary">
+    <div class="card bg-base-100 border-t-4 border-primary">
       <div class="card-body">
         <div class="flex items-center justify-center gap-3 mb-6">
           <.icon name="heart" />
@@ -233,7 +233,7 @@ defmodule WedidWeb.AppComponents do
 
   def add_moment_button(assigns) do
     ~H"""
-    <a href={~p"/entries"} class={[@class, "animate-pulse"]}>
+    <a href={~p"/entries"} class={@class}>
       <.icon name="plus" /> See all moments
     </a>
     """

--- a/lib/wedid_web/live/user/settings_live.ex
+++ b/lib/wedid_web/live/user/settings_live.ex
@@ -87,6 +87,24 @@ defmodule WedidWeb.User.SettingsLive do
     end
   end
 
+  attr :theme, :string, required: true, doc: "name of the theme"
+  attr :label, :string, required: true, doc: "name of the theme"
+
+  defp theme_button(assigns) do
+    ~H"""
+    <li>
+      <input
+        type="radio"
+        name="theme-dropdown"
+        class="theme-controller btn btn-sm btn-block btn-ghost justify-start checked:btn-active checked:bg-primary"
+        aria-label={@label}
+        value={@theme}
+        data-set-theme={@theme}
+      />
+    </li>
+    """
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -97,7 +115,11 @@ defmodule WedidWeb.User.SettingsLive do
         </.header>
 
         <.card title="Color theme">
-          <WedidWeb.Layouts.theme_toggle />
+          <p>Select a color theme for the application.</p>
+
+          <:actions>
+            <.theme_switcher id="theme-switcher" />
+          </:actions>
         </.card>
 
         <.card title="Profile information">
@@ -113,29 +135,88 @@ defmodule WedidWeb.User.SettingsLive do
             Use this to set your password after being invited to the application or if you have
             forgotten your password and signed-in with a magic link.
           </p>
-          <.button
-            type="submit"
-            variant="primary"
-            phx-click="request_password_reset"
-            phx-disable-with="Requesting..."
-          >
-            Request password reset link
-          </.button>
+
+          <:actions>
+            <.button
+              type="submit"
+              variant="primary"
+              phx-click="request_password_reset"
+              phx-disable-with="Requesting..."
+            >
+              Request password reset link
+            </.button>
+          </:actions>
         </.card>
       </div>
     </Layouts.app>
     """
   end
 
+  attr :id, :string, required: true, doc: "the dom id of the modal"
+
+  def theme_switcher(assigns) do
+    ~H"""
+    <div class="dropdown " title="Change Theme" id={@id} phx-hook="ThemeSwitcher">
+      <div tabindex="0" role="button" class="btn btn-primary">
+        Theme
+        <svg
+          width="12px"
+          height="12px"
+          class="h-2 w-2 fill-current opacity-60 inline-block"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 2048 2048"
+        >
+          <path d="M1799 349l242 241-1017 1017L7 590l242-241 775 775 775-775z"></path>
+        </svg>
+      </div>
+      <ul tabindex="0" class="dropdown-content z-[1] p-2 shadow-2xl bg-base-300 rounded-box w-52">
+        <.theme_button theme="light" label="Default" />
+        <.theme_button theme="dark" label="Dark" />
+        <.theme_button theme="cupcake" label="Cupcake" />
+        <.theme_button theme="bumblebee" label="Bumblebee" />
+        <.theme_button theme="emerald" label="Emerald" />
+        <.theme_button theme="corporate" label="Corporate" />
+        <.theme_button theme="synthwave" label="Synthwave" />
+        <.theme_button theme="retro" label="Retro" />
+        <.theme_button theme="cyberpunk" label="Cyberpunk" />
+        <.theme_button theme="valentine" label="Valentine" />
+        <.theme_button theme="halloween" label="Halloween" />
+        <.theme_button theme="garden" label="Garden" />
+        <.theme_button theme="forest" label="Forest" />
+        <.theme_button theme="aqua" label="Aqua" />
+        <.theme_button theme="lofi" label="Lofi" />
+        <.theme_button theme="pastel" label="Pastel" />
+        <.theme_button theme="fantasy" label="Fantasy" />
+        <.theme_button theme="wireframe" label="Wireframe" />
+        <.theme_button theme="black" label="Black" />
+        <.theme_button theme="luxury" label="Luxury" />
+        <.theme_button theme="dracula" label="Dracula" />
+        <.theme_button theme="cmyk" label="CMYK" />
+        <.theme_button theme="autumn" label="Autumn" />
+        <.theme_button theme="business" label="Business" />
+        <.theme_button theme="acid" label="Acid" />
+        <.theme_button theme="lemonade" label="Lemonade" />
+        <.theme_button theme="night" label="Night" />
+        <.theme_button theme="coffee" label="Coffee" />
+        <.theme_button theme="winter" label="Winter" />
+      </ul>
+    </div>
+    """
+  end
+
   attr :title, :string, required: true, doc: "the title of the card"
   slot :inner_block, required: true, doc: "the content to render inside the card"
+  slot :actions, required: false, doc: "optional actions to render in the card footer"
 
   def card(assigns) do
     ~H"""
-    <div class="card bg-base-100 shadow-xl mb-6">
+    <div class="card card-border mb-6">
       <div class="card-body">
         <h2 class="card-title">{@title}</h2>
         {render_slot(@inner_block)}
+        <div :if={@actions != []} class="card-actions mt-5 justify-end">
+          {render_slot(@actions)}
+        </div>
       </div>
     </div>
     """

--- a/test/wedid_web/live/user/settings_live_test.exs
+++ b/test/wedid_web/live/user/settings_live_test.exs
@@ -33,4 +33,48 @@ defmodule WedidWeb.User.SettingsLiveTest do
       assert updated_user.name == "Updated Test Name"
     end
   end
+
+  # the tests for this might need to be rewritten in PhoenixTest
+  describe "Theme Switcher" do
+    setup :register_and_log_in_user
+
+    @tag :skip
+    test "renders theme controller and checks initial theme", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      assert has_element?(view, "#theme-switcher")
+      assert has_element?(view, "input[data-set-theme='light'][aria-label='Default']")
+      assert has_element?(view, "input[data-set-theme='dark'][aria-label='Dark']")
+      assert has_element?(view, "input[data-set-theme='cupcake'][aria-label='Cupcake']")
+
+      assert view |> element(~s|html[data-theme="light"]|) |> has_element?()
+
+      # Re-fetch the view to ensure JavaScript has run
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      default_radio_checked =
+        has_element?(view, "input[data-set-theme='light'][aria-label='Default']:checked")
+
+      assert default_radio_checked
+    end
+
+    # Skipping this test. LiveViewTest cant handle JavaScript interactions directly.
+    @tag :skip
+    test "selecting a theme updates data-theme", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      view
+      |> element("input[data-set-theme='cupcake']")
+      |> render_click()
+
+      # Wait for DOM changes if necessary, though click should be synchronous for this
+      Process.sleep(100)
+
+      assert view |> element(~s|html[data-theme="cupcake"]|) |> has_element?()
+
+      {:ok, view, _html} = live(conn, ~p"/settings")
+
+      assert view |> element(~s|html[data-theme="cupcake"]|) |> has_element?()
+    end
+  end
 end


### PR DESCRIPTION
This commit introduces a theme switcher to your user settings page, allowing you to select your preferred UI theme.

Key changes:

- Added 27 new themes from daisyUI to `assets/css/app.css`.
- Created `assets/js/theme_switcher.js` to handle:
    - Loading the saved theme from local storage on page load.
    - Applying the selected theme to the `html` element's `data-theme` attribute.
    - Saving the selected theme to local storage.
    - Updating the theme dropdown to reflect the active theme.
- Imported and initialized the theme switcher in `assets/js/app.js`.
- Integrated the daisyUI theme controller (dropdown version) into the `lib/wedid_web/live/user/settings_live.ex` LiveView. The existing theme toggle was replaced.
- Added LiveView tests in `test/wedid_web/live/user/settings_live_test.exs`. (those need to be rewritten since LiveView test cant test client-side javascript)