### PR TITLE
Fix invite action to take couple from actor

### DIFF
--- a/lib/wedid/accounts.ex
+++ b/lib/wedid/accounts.ex
@@ -7,7 +7,7 @@ defmodule Wedid.Accounts do
     resource Wedid.Accounts.Token
 
     resource Wedid.Accounts.User do
-      define :invite_user, action: :invite, args: [:email, :couple_id]
+      define :invite_user, action: :invite, args: [:email]
       define :list_users, action: :read
       define :update_user_profile, action: :update_profile, args: [:name]
       define :change_password, action: :change_password

--- a/lib/wedid/accounts/user.ex
+++ b/lib/wedid/accounts/user.ex
@@ -289,12 +289,7 @@ defmodule Wedid.Accounts.User do
       description "Invite a user to join a couple."
       accept [:email]
 
-      # FIXME: change this to take couple_id from the actor
-      argument :couple_id, :uuid do
-        allow_nil? false
-      end
-
-      change set_attribute(:couple_id, arg(:couple_id))
+      change set_attribute(:couple_id, actor(:couple_id))
 
       # TODO move into own file
       change fn changeset, _context ->

--- a/lib/wedid_web/live/couple/couple_live.ex
+++ b/lib/wedid_web/live/couple/couple_live.ex
@@ -37,7 +37,6 @@ defmodule WedidWeb.Couple.CoupleLive do
   @impl true
   def handle_event("invite_partner", %{"form" => form_data}, socket) do
     current_user = socket.assigns.current_user
-    form_data = Map.put(form_data, "couple_id", current_user.couple_id)
 
     case AshPhoenix.Form.submit(socket.assigns.form, params: form_data) do
       {:ok, _invited_user} ->

--- a/test/wedid/accounts/couple_test.exs
+++ b/test/wedid/accounts/couple_test.exs
@@ -6,7 +6,7 @@ defmodule Wedid.Accounts.CoupleTest do
     test "can list users" do
       user = generate(AccountsGenerator.user())
       email = Faker.Internet.email()
-      Wedid.Accounts.invite_user!(email, user.couple_id, actor: user)
+      Wedid.Accounts.invite_user!(email, actor: user)
 
       # users with the couple id exist
       users = Ash.Query.filter(User, couple_id == ^user.couple_id) |> Ash.read!(authorize?: false)

--- a/test/wedid/diaries/authorization_test.exs
+++ b/test/wedid/diaries/authorization_test.exs
@@ -24,7 +24,7 @@ defmodule Wedid.Diaries.AuthorizationTest do
     test "others can update couples entries" do
       user = generate(user())
       entry = generate(entry(actor: user))
-      partner = Accounts.invite_user!(Faker.Internet.email(), user.couple_id, actor: user)
+      partner = Accounts.invite_user!(Faker.Internet.email(), actor: user)
       assert Diaries.can_update_entry?(partner, entry, %{content: "Great day!"})
     end
   end

--- a/test/wedid/diaries/diaries_test.exs
+++ b/test/wedid/diaries/diaries_test.exs
@@ -59,7 +59,7 @@ defmodule Wedid.Diaries.DiariesTest do
     test "list_entries with a query" do
       user = generate(user())
       generate(entry(actor: user))
-      partner = Accounts.invite_user!(Faker.Internet.email(), user.couple_id, actor: user)
+      partner = Accounts.invite_user!(Faker.Internet.email(), actor: user)
       generate(entry(actor: partner))
 
       entries =

--- a/test/wedid/diaries/entry_test.exs
+++ b/test/wedid/diaries/entry_test.exs
@@ -9,7 +9,7 @@ defmodule Wedid.Diaries.EntryTest do
     setup do
       # Create a user for testing
       user = generate(AccountsGenerator.user())
-      partner = Wedid.Accounts.invite_user!(Faker.Internet.email(), user.couple_id, actor: user)
+      partner = Wedid.Accounts.invite_user!(Faker.Internet.email(), actor: user)
 
       # Create another user with different couple
       another_user = generate(AccountsGenerator.user())

--- a/test/wedid/diaries/entrytag_test.exs
+++ b/test/wedid/diaries/entrytag_test.exs
@@ -288,7 +288,7 @@ defmodule Wedid.Diaries.EntryTagTest do
   describe "EntryTag with partner in couple" do
     test "partner can create EntryTags for entries in the shared couple" do
       user = generate(user())
-      partner = Accounts.invite_user!(Faker.Internet.email(), user.couple_id, actor: user)
+      partner = Accounts.invite_user!(Faker.Internet.email(), actor: user)
       
       # Create entry by user, tag by partner
       entry = generate(entry(actor: user))
@@ -310,7 +310,7 @@ defmodule Wedid.Diaries.EntryTagTest do
 
     test "partner can manage EntryTags in the shared couple" do
       user = generate(user())
-      partner = Accounts.invite_user!(Faker.Internet.email(), user.couple_id, actor: user)
+      partner = Accounts.invite_user!(Faker.Internet.email(), actor: user)
       
       entry = generate(entry(actor: user))
       tag = generate(tag(actor: user))


### PR DESCRIPTION
## Summary
- ensure `invite` action sets the couple from the actor
- update domain interface and live view
- adjust tests to match new API

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856715013e08323b1384a63732d9f58