### PR TITLE
Add language switcher to guest navbar

### DIFF
--- a/assets/js/locale_switcher.js
+++ b/assets/js/locale_switcher.js
@@ -1,7 +1,7 @@
 export default LocaleSwitcher = {
   mounted() {
     // Handle locale change events from the server
-    this.handleEvent("locale-changed", ({locale, shouldReload = true}) => {
+    this.handleEvent("locale-changed", ({ locale, shouldReload = true }) => {
       this.setLocale(locale);
 
       if (shouldReload) {
@@ -15,7 +15,7 @@ export default LocaleSwitcher = {
 
   selectedLocale() {
     return this.el.dataset.currentLocale;
-	},
+  },
 
   setLocale(locale) {
     localStorage.setItem("locale", locale);
@@ -30,43 +30,74 @@ export default LocaleSwitcher = {
     if (this.selectedLocale() !== locale) {
       this.pushEvent("sync_locale", { locale });
     }
-	},
+  },
 
   setLocaleCookie(locale) {
     const expires = new Date();
-    expires.setTime(expires.getTime() + (365 * 24 * 60 * 60 * 1000)); // 1 year
+    expires.setTime(expires.getTime() + 365 * 24 * 60 * 60 * 1000); // 1 year
     document.cookie = `locale=${locale}; path=/; expires=${expires.toUTCString()}`;
   },
 
   reloadWithLocale(locale) {
     const url = new URL(window.location);
-    url.searchParams.set('locale', locale);
+    url.searchParams.set("locale", locale);
     setTimeout(() => {
       window.location.href = url.toString();
     }, 100);
-  }
+  },
 };
 
+let localeLinksInitialized = false;
+
 function deviceLocale() {
-  return localStorage.getItem("locale") || 'de';
+  return localStorage.getItem("locale") || "de";
 }
 
 function setDeviceLocale(locale) {
-	localStorage.setItem("locale", locale);
-	document.documentElement.setAttribute("lang", locale);
+  localStorage.setItem("locale", locale);
+  document.documentElement.setAttribute("lang", locale);
+}
+
+function attachLocaleLinkHandlers() {
+  if (localeLinksInitialized) {
+    return;
+  }
+
+  localeLinksInitialized = true;
+
+  document.addEventListener(
+    "click",
+    (event) => {
+      const target = event.target.closest("[data-locale-link]");
+
+      if (!target) {
+        return;
+      }
+
+      const { locale } = target.dataset;
+
+      if (locale) {
+        setDeviceLocale(locale);
+      }
+    },
+    true,
+  );
 }
 
 // Initialize locale immediately when script loads
 export function initLocale() {
   document.documentElement.setAttribute("lang", deviceLocale());
+  attachLocaleLinkHandlers();
 }
 
 // Export function to change locale programmatically
 export function changeLocale(locale) {
   setDeviceLocale(locale);
-  
+
   // Trigger a custom event that LiveView can listen to
-  window.dispatchEvent(new CustomEvent("locale-change", { 
-    detail: { locale: locale } 
-  }));
+  window.dispatchEvent(
+    new CustomEvent("locale-change", {
+      detail: { locale: locale },
+    }),
+  );
 }

--- a/lib/wedid_web/components/app_components.ex
+++ b/lib/wedid_web/components/app_components.ex
@@ -10,6 +10,7 @@ defmodule WedidWeb.AppComponents do
   use Gettext, backend: WedidWeb.Gettext
   alias WedidWeb.CoreComponents, as: Core
   alias Phoenix.LiveView.JS
+  alias WedidWeb.Locale
 
   @doc """
   Renders a single entry in the journal.
@@ -76,8 +77,12 @@ defmodule WedidWeb.AppComponents do
       <.navbar current_user={@current_user} />
   """
   attr :current_user, :map, default: nil, doc: "the current user if signed in"
+  attr :current_locale, :string, default: nil, doc: "the currently active locale"
 
   def navbar(assigns) do
+    assigns =
+      assign_new(assigns, :current_locale, fn -> Locale.current_locale() end)
+
     ~H"""
     <div class="navbar bg-primary text-primary-content shadow-md">
       <div class="navbar-start">
@@ -123,7 +128,13 @@ defmodule WedidWeb.AppComponents do
         <%= if @current_user do %>
           <Core.user_menu current_user={@current_user} />
         <% else %>
-          <.auth_buttons />
+          <div class="flex items-center gap-2">
+            <.language_switcher
+              id="navbar-language-switcher"
+              current_locale={@current_locale}
+            />
+            <.auth_buttons />
+          </div>
         <% end %>
       </div>
     </div>
@@ -163,6 +174,69 @@ defmodule WedidWeb.AppComponents do
     <a href="/register" class="btn btn-secondary btn-sm ml-2">
       {gettext("Sign up")}
     </a>
+    """
+  end
+
+  @doc """
+  Renders the language switcher dropdown used throughout the application.
+
+  ## Examples
+
+      <.language_switcher id="language-switcher" current_locale="en" change_event="change_locale" />
+  """
+  attr :id, :string, default: nil, doc: "the DOM id of the language switcher"
+  attr :current_locale, :string, default: nil, doc: "the locale currently selected"
+  attr :change_event, :string, default: nil, doc: "optional phx-click event for LiveView integration"
+
+  def language_switcher(assigns) do
+    assigns = assign_new(assigns, :current_locale, fn -> Locale.current_locale() end)
+
+    assigns =
+      assigns
+      |> assign(:current_locale_flag, Locale.locale_flag(assigns.current_locale))
+      |> assign(:current_locale_name, Locale.locale_name(assigns.current_locale))
+
+    ~H"""
+    <div
+      class="dropdown"
+      title={gettext("Change Language")}
+      id={@id}
+      phx-hook="LocaleSwitcher"
+      data-current-locale={@current_locale}
+    >
+      <div tabindex="0" role="button" class="btn btn-primary">
+        {@current_locale_flag}
+        {@current_locale_name}
+        <svg
+          width="12px"
+          height="12px"
+          class="h-2 w-2 fill-current opacity-60 inline-block"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 2048 2048"
+        >
+          <path d="M1799 349l242 241-1017 1017L7 590l242-241 775 775 775-775z"></path>
+        </svg>
+      </div>
+      <ul tabindex="0" class="dropdown-content z-[1] p-2 shadow-2xl bg-base-300 rounded-box w-52">
+        <%= for locale <- Locale.supported_locales() do %>
+          <li>
+            <a
+              href={"?locale=#{locale.code}"}
+              class={
+                "btn btn-sm btn-block btn-ghost justify-start " <>
+                  if(locale.code == @current_locale, do: "btn-active bg-primary", else: "")
+              }
+              data-locale-link
+              data-locale={locale.code}
+              phx-click={@change_event}
+              phx-value-locale={locale.code}
+            >
+              {locale.flag} {locale.name}
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
     """
   end
 

--- a/lib/wedid_web/live/user/settings_live.ex
+++ b/lib/wedid_web/live/user/settings_live.ex
@@ -169,7 +169,11 @@ defmodule WedidWeb.User.SettingsLive do
           <p>{gettext("Select your preferred language for the application.")}</p>
 
           <:actions>
-            <.language_switcher id="language-switcher" current_locale={@current_locale} />
+            <.language_switcher
+              id="language-switcher"
+              current_locale={@current_locale}
+              change_event="change_locale"
+            />
           </:actions>
         </.card>
 
@@ -252,49 +256,6 @@ defmodule WedidWeb.User.SettingsLive do
         <.theme_button theme="night" label="Night" />
         <.theme_button theme="coffee" label="Coffee" />
         <.theme_button theme="winter" label="Winter" />
-      </ul>
-    </div>
-    """
-  end
-
-  attr :id, :string, required: true, doc: "the dom id of the language switcher"
-  attr :current_locale, :string, required: true, doc: "the current locale"
-
-  def language_switcher(assigns) do
-    ~H"""
-    <div
-      class="dropdown"
-      title="Change Language"
-      id={@id}
-      phx-hook="LocaleSwitcher"
-      data-current-locale={@current_locale}
-    >
-      <div tabindex="0" role="button" class="btn btn-primary">
-        {WedidWeb.Locale.locale_flag(@current_locale)}
-        {WedidWeb.Locale.locale_name(@current_locale)}
-        <svg
-          width="12px"
-          height="12px"
-          class="h-2 w-2 fill-current opacity-60 inline-block"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 2048 2048"
-        >
-          <path d="M1799 349l242 241-1017 1017L7 590l242-241 775 775 775-775z"></path>
-        </svg>
-      </div>
-      <ul tabindex="0" class="dropdown-content z-[1] p-2 shadow-2xl bg-base-300 rounded-box w-52">
-        <%= for locale <- WedidWeb.Locale.supported_locales() do %>
-          <li>
-            <button
-              type="button"
-              class={"btn btn-sm btn-block btn-ghost justify-start #{if locale.code == @current_locale, do: "btn-active bg-primary", else: ""}"}
-              phx-click="change_locale"
-              phx-value-locale={locale.code}
-            >
-              {locale.flag} {locale.name}
-            </button>
-          </li>
-        <% end %>
       </ul>
     </div>
     """

--- a/test/wedid_web/components/navbar_language_switcher_test.exs
+++ b/test/wedid_web/components/navbar_language_switcher_test.exs
@@ -1,0 +1,30 @@
+defmodule WedidWeb.NavbarLanguageSwitcherTest do
+  use WedidWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  describe "guest navbar language switcher" do
+    test "renders language switcher for guests" do
+      html =
+        render_component(&WedidWeb.AppComponents.navbar/1, %{
+          current_user: nil,
+          current_locale: "en"
+        })
+
+      assert html =~ "id=\"navbar-language-switcher\""
+      assert html =~ "English"
+      assert html =~ "Deutsch"
+    end
+
+    test "language switcher links point to locale query parameter" do
+      html =
+        render_component(&WedidWeb.AppComponents.navbar/1, %{
+          current_user: nil,
+          current_locale: "en"
+        })
+
+      assert html =~ "href=\"?locale=en\""
+      assert html =~ "href=\"?locale=de\""
+    end
+  end
+end

--- a/test/wedid_web/locale_test.exs
+++ b/test/wedid_web/locale_test.exs
@@ -147,7 +147,7 @@ defmodule WedidWeb.LocaleTest do
 
       result =
         view
-        |> element("button[phx-click='change_locale'][phx-value-locale='de']")
+        |> element("a[phx-click='change_locale'][phx-value-locale='de']")
         |> render_click()
 
       # The click should succeed without error


### PR DESCRIPTION
## Summary
- expose a reusable language switcher component and render it next to guest auth actions in the navbar
- reuse the shared switcher on the settings page and enhance the locale hook to work without LiveView
- cover the navbar language selector with component tests and adjust existing locale tests

## Testing
- mix test *(fails: `mix` command is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c976f04bbc832380ebaaebaf0e2dec